### PR TITLE
add @scalar/fastify-api-reference to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Plugins maintained by the fastify team are listed under [Core](#core) while plug
 - [`fastify-orientdb`](https://github.com/mahmed8003/fastify-orientdb) Fastify OrientDB connection plugin, with which you can share the OrientDB connection across every part of your server.
 - [`fastify-response-time`](https://github.com/lolo32/fastify-response-time) Add `X-Response-Time` header at each request for Fastify, in milliseconds.
 - [`fastify-rob-config`](https://github.com/jeromemacias/fastify-rob-config) Fastify Rob-Config integration.
+- [`fastify-api-reference`](https://github.com/scalar/scalar/tree/main/packages/fastify-api-reference) Beautiful OpenAPI/Swagger documentation generator for Fastify.
 - [`fastify-sequelize`](https://github.com/lyquocnam/fastify-sequelize) Fastify plugin work with Sequelize (adapter for NodeJS -> Sqlite, Mysql, Mssql, Postgres).
 - [`fastify-server-session`](https://github.com/jsumners/fastify-server-session) A session plugin with support for arbitrary backing caches via `fastify-caching`.
 - [`fastify-session`](https://github.com/SerayaEryn/fastify-session) a session plugin for Fastify.


### PR DESCRIPTION
This PR adds @scalar/fastrify-api-reference to the list of community plugins for fastify. ⚡️

Read more about it here: https://github.com/scalar/scalar/tree/main/packages/fastify-api-reference